### PR TITLE
download ximagesrc from steamos repo

### DIFF
--- a/install-recapture-cli.sh
+++ b/install-recapture-cli.sh
@@ -39,6 +39,16 @@ mv recapture_dl_dir/plugin/recapture/dist/deps/* $HOME/.local/recapture
 # Make Recapture binary executable
 chmod +x $HOME/.local/recapture/recapture
 
+sleep 1
+# For the screen recording to work in Desktop mode, we require gstreamer good plugin libgstximagesrc.so
+# Lets download it form steamos extra-rel repo
+mkdir -p /tmp/recapture_dl_dir/plugin/good
+	wget \
+		-O recapture_dl_dir/gst-plugins-good.pkg.tar.zst \
+		https://steamdeck-packages.steamos.cloud/archlinux-mirror/extra-rel/os/x86_64/gst-plugins-good-1.20.4-1-x86_64.pkg.tar.zst
+	tar --use-compress-program=unzstd -xf recapture_dl_dir/gst-plugins-good.pkg.tar.zst -C recapture_dl_dir/plugin/good
+	cp recapture_dl_dir/plugin/good/usr/lib/gstreamer-1.0/libgstximagesrc.so $HOME/.local/recapture/plugins/good
+
 # Download Recapture CLI wrapper
 wget -O recapture_dl_dir/recapture-cli-wrapper.sh \
         https://raw.githubusercontent.com/m-rzb/Screen-recorder-for-steamdeck/main/recapture-cli-wrapper.sh


### PR DESCRIPTION
ximagesrc (Gstreamer good plugin) is required for the screen recording to be working in Desktop mode. It will be downloaded from the steamos extra-rel repo